### PR TITLE
feat: Add header and help page

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const Header: React.FC = () => {
+  return (
+    <header className="bg-gray-800 text-white p-4 flex justify-between items-center">
+      <h1 className="text-xl font-bold">Online Sticky Notes</h1>
+      <nav>
+        <a href="/" className="px-3 py-2 hover:bg-gray-700 rounded-md">Board</a>
+        <a href="/help" className="px-3 py-2 hover:bg-gray-700 rounded-md ml-2">Help</a>
+      </nav>
+    </header>
+  );
+};
+
+export default Header;

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -1,5 +1,6 @@
 import { AppProps } from "$fresh/server.ts";
 import { Head } from "$fresh/runtime.ts";
+import Header from "../components/Header.tsx";
 
 export default function App(props: AppProps) {
   return (
@@ -7,6 +8,7 @@ export default function App(props: AppProps) {
       <Head>
         <title>付箋共有</title>
       </Head>
+      <Header />
       <props.Component />
     </>
   );

--- a/routes/help.tsx
+++ b/routes/help.tsx
@@ -1,0 +1,22 @@
+import { Head } from "$fresh/runtime.ts";
+
+export default function HelpPage() {
+  return (
+    <>
+      <Head>
+        <title>Help - Online Sticky Notes</title>
+      </Head>
+      <div className="p-8 max-w-2xl mx-auto">
+        <h1 className="text-3xl font-bold mb-4">Help</h1>
+        <h2 className="text-xl font-bold mb-2">How to Use the Sticky Notes Board</h2>
+        <ul className="list-disc pl-5">
+          <li className="mb-2">Create a new sticky note: Click anywhere on the empty board.</li>
+          <li className="mb-2">Edit a sticky note: Click inside the text area of a sticky note and start typing.</li>
+          <li className="mb-2">Move a sticky note: Click and drag the sticky note (but not on the text area or resize handle).</li>
+          <li className="mb-2">Resize a sticky note: Click and drag the resize handle at the bottom-right corner of a sticky note.</li>
+          <li className="mb-2">Delete a sticky note: Click the '❎' icon at the top-right corner of a sticky note.</li>
+        </ul>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
This commit introduces two main enhancements to the application:

1.  A persistent header:
    - Displays the application title "Online Sticky Notes".
    - Provides navigation links to the "Board" (main page) and a new "Help" page.
    - The header is implemented in `components/Header.tsx` and integrated via `routes/_app.tsx`.

2.  A help page:
    - Accessible at the `/help` route.
    - Provides you with basic instructions on how to create, edit, move, resize, and delete sticky notes.
    - Implemented in `routes/help.tsx`.

Basic Tailwind CSS styling has been applied to both the header and the help page for better visual presentation.